### PR TITLE
Add codebase tagging fns to util.clj and use them in hello_world example

### DIFF
--- a/examples/hello_world.clj
+++ b/examples/hello_world.clj
@@ -40,6 +40,14 @@
                                                         :sim/systemURI (str "datomic:mem://" (squuid))
                                                       :sim/processCount 10}))
 
+(defn assoc-codebase-tx [entities]
+  (let [codebase (gen-codebase)
+        cid (:db/id codebase)]
+    (cons
+     codebase
+     (mapv #(assoc {:db/id (:db/id %)} :source/codebase cid) entities))))
+(transact sim-conn (assoc-codebase-tx [trading-test trading-sim]))
+
 ;; clock for this sim
 (def sim-clock (sim/create-fixed-clock sim-conn trading-sim {:clock/multiplier 480}))
 
@@ -107,7 +115,3 @@
 ;; sim written in hopes that balances will not go negative
 ;; but they might, because system under test does not check!
 (filter neg? trader-balances)
-
-
-
-

--- a/resources/datomic-sim/schema.dtm
+++ b/resources/datomic-sim/schema.dtm
@@ -212,4 +212,32 @@
                         (not (some (fn [[e]] (= e procid)) procs)))
                [[:db/add simid :sim/processes procid]
                 proc
-                [:db/add procid :process/ordinal (count procs)]]))}}]]}
+                [:db/add procid :process/ordinal (count procs)]]))}}]]
+
+ :codebase
+ [[{:db/id #db/id [:db.part/db]
+    :db/ident :source/codebase
+    :db/valueType :db.type/ref
+    :db/doc "Reference to information about the source tree"
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id #db/id[:db.part/db]
+    :db/ident :repo.type/git}
+   {:db/id #db/id[:db.part/db]
+    :db/ident :repo/type
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc "Type of repository"
+    :db.install/_attribute :db.part/db}
+   {:db/id #db/id[:db.part/db]
+    :db/ident :git/uri
+    :db/valueType :db.type/string
+    :db/doc "Git repository URI"
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}
+   {:db/id #db/id [:db.part/db]
+    :db/ident :git/sha
+    :db/valueType :db.type/string
+    :db/doc "SHA ref for current git HEAD"
+    :db/cardinality :db.cardinality/one
+    :db.install/_attribute :db.part/db}]]}


### PR DESCRIPTION
This branch adds the codebase tagging features requested earlier this week.

I've tried to place functions as best I could in the appropriate location (example vs. library), however I think `assoc-codebase-tx` kind of sits on the line between library function and example usage. For now I've left it as part of the example code. Your opinion would be appreciated.

I'm also not terribly happy with `gen-codebase` as a function name. Suggestions welcomed.
