### PR TITLE
deref transact future to avoid silent failure on malformed schema

### DIFF
--- a/examples/simulant/examples/repl.clj
+++ b/examples/simulant/examples/repl.clj
@@ -25,7 +25,7 @@
   (let [m (-> resource io/resource slurp read-string)]
     (doseq [v (vals m)]
       (doseq [tx v]
-        (d/transact conn tx)))))
+        @(d/transact conn tx)))))
 
 (defn convenient
   []


### PR DESCRIPTION
If you use this function and get the schema wrong, it fails silently. Derefing immediately fixes it.
