### PR TITLE
Replace reader's read-string with safer edn's read-string

### DIFF
--- a/src/simulant/util.clj
+++ b/src/simulant/util.clj
@@ -8,6 +8,7 @@
 
 (ns simulant.util
   (:require
+   [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [datomic.api :as d]))
@@ -162,9 +163,7 @@
 (defn safe-read-string
   "Read a string without evaluating its contents"
   [str]
-  (binding [*read-eval* false]
-    (when (pos? (count str))
-      (read-string str))))
+  (edn/read-string str))
 
 (defn form-seq
   "Lazy seq of forms read from a reader"


### PR DESCRIPTION
Sure, Simulant should not have to execute malicious inputs but this change makes it cleaner and safer with less/no regression.
