### PR TITLE
Clean up the URI used for process-state databases.

### DIFF
--- a/src/simulant/sim.clj
+++ b/src/simulant/sim.clj
@@ -170,7 +170,7 @@ process."
 
 (defn construct-process-state
   [_ _]
-  (->ProcessStateService (str "datomic:mem://localhost:4334/" (gensym))))
+  (->ProcessStateService (str "datomic:mem://" (gensym))))
 
 (defn create-process-state
   "Mark the fact that a sim will use a process state service."


### PR DESCRIPTION
- removed localhost:4334 from the URI
- its inclusion is unnecessary for an in-memory datomic db
