### PR TITLE
Bind *print-length* to nil around action-log printing.

### DIFF
--- a/src/simulant/sim.clj
+++ b/src/simulant/sim.clj
@@ -132,7 +132,8 @@ process."
    (send-off
     serializer
     (fn [_]
-      (binding [*out* writer]
+      (binding [*out* writer
+                *print-length* nil]
         (pr tx-data))
       nil))))
 


### PR DESCRIPTION
Fixes #21.